### PR TITLE
Adjust end of year processing

### DIFF
--- a/R/fdk_get_sequence.R
+++ b/R/fdk_get_sequence.R
@@ -187,7 +187,7 @@ get_sequence_byvar <- function(site, df, good, leng_threshold, do_merge){
           lubridate::year(start),
           lubridate::year(start) + 1),
         year_end = ifelse(
-          lubridate::yday(end) >= 365,
+          lubridate::month(end) == 12 & lubridate::day(end) >= 30,
           lubridate::year(end),
           lubridate::year(end) - 1
         )) |>


### PR DESCRIPTION
This PR makes a small change to determining the final year of the sequences per site. The current approach does this based on the day of the year, which introduces a difference in outcome between leap years and non-leap years. Particularly, since most sequences end on December 30th instead of 31st, the sequence includes this final year for leap years while it doesn't for non-leap years.

I suggest to set the cutoff date to December 30th, since otherwise the final almost-complete year is removed for 170 sites. What do you think @stineb ?